### PR TITLE
Fix incorrect subnet selection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*.swp
+
+terraform.tfstate
+terraform.tfstate.*
+
+.terraform
+.terragrunt-cache

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,4 +3,9 @@ pipeline:
     image: hashicorp/terraform
     commands:
       - apk add make
-      - make
+      - make tfc
+  linter:
+    image: python:3
+    commands:
+      - pip3 install --extra-index-url https://pip-test.techservices.illinois.edu/index/test tflint
+      - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,13 @@ RUN apk add make
 WORKDIR /tmp
 COPY . /tmp
 
-ENTRYPOINT [ "/usr/bin/make" ]
+ENTRYPOINT [ "/usr/bin/make", "tfc" ]
+
+FROM python:3
+
+RUN pip3 install --extra-index-url https://pip-test.techservices.illinois.edu/index/test tflint
+
+WORKDIR /tmp
+COPY . /tmp
+
+ENTRYPOINT [ "/usr/bin/make", "test" ]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 by the Board of Trustees of the University of Illinois.
+Copyright (c) 2019 by the Board of Trustees of the University of Illinois.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,63 @@
-.PHONY: test clean docker sh shell
+.PHONY: test tfc clean docker sh shell
 
 REPO := $(shell basename $(shell git remote get-url origin) .git)
 
-test: .terraform
+GOPTS := -lR . -e
+GREP := grep $(GOPTS)
+EGREP := egrep $(GOPTS)
+SRCS := --include=*.tf
+DOCS := --include=README.md
+
+all: tfc test
+
+tfc: .terraform
+	@# Basic Terraform validation and formating checks
+	terraform version
 	AWS_DEFAULT_REGION=us-east-2 terraform validate
-	terraform fmt -check
-	! egrep "TF-UPGRADE-TODO|cites-illinois|as-aws-modules" *.tf README.md
-	# Do NOT put terraform-aws in the title
+	terraform fmt -check -recursive
+
+# Create .terraform if does not exist
+# A terraform init is requried to run a validate :-(
+.terraform:
+	terraform init -backend=false
+	terraform version
+
+test:
+	@####################################################
+	! $(EGREP) "TF-UPGRADE-TODO|cites-illinois|as-aws-modules" $(SRCS) $(DOCS)
+	# Do NOT put terraform-aws in the title of the top-level README
 	! grep "#\s*terraform-aws-" README.md
 	# Do NOT use type string when you can use type number or bool!
-	! egrep '"\d+"|"true"|"false"' *.tf README.md
+	! $(EGREP) '"\d+"|"true"|"false"' $(SRCS) $(DOCS)
 	# Do NOT use old style maps in docs
-	! egrep "\w+\s*\{" README.md
+	! $(EGREP) "\w+\s*\{" $(DOCS)
 	# Do NOT drop the "s" in outputs.tf or variables.tf!
 	! find . -name output.tf -o -name variable.tf | grep '.*'
 	# Do NOT define an output in files other than outputs.tf
-	! egrep 'output\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name outputs.tf)
+	! $(EGREP) 'output\s+"\w+"\s*\{' $(SRCS) --exclude=outputs.tf
 	# Do NOT define a variable in files other than variables.tf
-	! egrep 'variable\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name variables.tf)
-	# DO put a badge in README.md
+	! $(EGREP) 'variable\s+"\w+"\s*\{' $(SRCS) --exclude=variables.tf
+	# DO put a badge in top-level README.md
 	grep -q "\[\!\[Build Status\]([^)]*$(REPO)/status.svg)\]([^)]*$(REPO))" README.md
+	# Do NOT split a source line over more than one line
+	! $(GREP) 'source\s*=\s*$$' $(SRCS) $(DOCS)
 	# Do NOT use ?ref= in source lines in a README.md!
-	! grep 'source\s*=.*?ref=' *.tf README.md
+	! $(GREP) 'source\s*=.*?ref=' $(DOCS)
 	# Do NOT start a source line with git::
-	! grep 'source\s*=\s*"git::' *.tf README.md
+	! $(GREP) 'source\s*=\s*"git::' $(SRCS) $(DOCS)
 	# Do NOT use .git in a source line
-	! grep 'source\s*=.*\.git.*"' *.tf README.md
+	! $(GREP) 'source\s*=.*\.git.*"' $(SRCS) $(DOCS)
+	# Do NOT use double slashes with top-level modules
+	! $(GREP) 'source\s*=.*//?ref=.*"' $(SRCS) $(DOCS)
+	# Do NOT leave extra whitespace at the end of a line
+	! $(EGREP) '\s+$$' $(SRCS)
+	# Do NOT leave empty lines at the start or end of a file
+	! find . -type f -name "*.tf" -exec sh -c "awk 'NR==1; END{print}' {} | egrep -q '^\s*$$' && echo {}" \; | grep '.*'
+	@# Run tflint if it is installed
+	@if which tflint >/dev/null; then tflint ; fi
 
 # Launches the Makefile inside a container
-docker: 
+docker:
 	docker build . -t test/$(REPO)
 	docker run --rm test/$(REPO)
 
@@ -42,10 +71,4 @@ shell:
 
 clean:
 	-rm -rf .terraform
-	-docker rmi test/$(REPO)
-
-# Create .terraform if does not exist
-# A terraform init is requried to run a validate :-(
-.terraform:
-	terraform init -backend=false
-	terraform version
+	-docker rmi -f test/$(REPO) >/dev/null 2>&1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,61 @@
 # cloud9-environment-ec2
 
 [![Build Status](https://drone.techservices.illinois.edu/api/badges/techservicesillinois/terraform-aws-cloud9-environment-ec2/status.svg)](https://drone.techservices.illinois.edu/techservicesillinois/terraform-aws-cloud9-environment-ec2)
+
+Provides a Cloud9 EC2 Development Environment.
+
+Example Usage
+-----------------
+
+The following example creates a Cloud9 EC2 environment in VPC
+`vpcName` in the lexicographically smallest availability zone (AZ)
+available in the given VPC. For a VPC using all AZs in us-east-2
+that would be `us-east-2a`.
+
+```
+module "service_name" {
+  source = "git@github.com:techservicesillinois/terraform-aws-cloud9-environment-ec2"
+
+  name        = "service"
+  description = "Environment for service development"
+  vpc         = "vpcName"
+
+  owner_arn = "arn:aws:sts::917683843710:assumed-role/roleName/netid@illinois.edu"
+```
+
+Argument Reference
+-----------------
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the environment.
+
+* `description` - (Required) The description of the environment.
+
+* `owner_arn` - (Required) The ARN of the environment owner.
+
+* `vpc` - (Required) VPC in which EC2 instance is to be placed.
+
+* `tier` - (Optional) Network tier in which to place EC2 instance (default public).
+
+* `instance_type` - (Optional) The type of instance to connect to the environment (default t2.nano).
+
+* `automatic_stop_time_minutes` - (Optional) Minutes until the instance is shut down after inactivity (default 30).
+
+Attributes Reference
+--------------------
+
+The following attributes are exported:
+
+* `id` - The ID of the environment.
+
+* `arn` - The ARN of the environment.
+
+* `type` - The type of the environment (e.g. ssh or ec2).
+
+Limitations
+-----------
+
+* The subnet where the EC2 instance resides can not be specified.
+
+* The selected VPC must have at most one subnet per availability zone (AZ).

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,18 @@
+data "aws_availability_zones" "selected" {}
+
 data "aws_vpc" "selected" {
   tags = {
     Name = var.vpc
   }
 }
 
-data "aws_subnet_ids" "selected" {
+data "aws_subnet" "selected" {
   vpc_id = data.aws_vpc.selected.id
+
+  filter {
+    name   = "availability-zone"
+    values = [local.az]
+  }
 
   tags = {
     Tier = var.tier
@@ -13,7 +20,8 @@ data "aws_subnet_ids" "selected" {
 }
 
 locals {
-  subnet_id = tolist(data.aws_subnet_ids.selected.ids)[0]
+  az        = sort(data.aws_availability_zones.selected.names)[0]
+  subnet_id = data.aws_subnet.selected.id
 }
 
 resource "aws_cloud9_environment_ec2" "default" {


### PR DESCRIPTION
The 0.11 code always selected a subnet in us-east-2a. The 0.12 code
does not behave this way. Now it does.